### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6
+
+WORKDIR /app
+ADD . /app
+RUN pip install --trusted-host pypi.python.org -r requirements.txt
+
+EXPOSE 8050
+
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -756,4 +756,4 @@ def make_count_figure(well_statuses, well_types, year_slider):
 
 # Main
 if __name__ == '__main__':
-    app.server.run(debug=True, threaded=True)
+    app.server.run(host='0.0.0.0', threaded=True, port=8050)


### PR DESCRIPTION
Allows to build the docker image with `docker build -t dash_oil_and_gas_demo`
and to run the container with `docker run -p 8050:8050 dash_oil_and_gas_demo`.